### PR TITLE
hardware/qcom/*-legacy: use kk branches

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -503,7 +503,7 @@
   </project>
 
   <!-- Device extras: legacy support -->
-  <project path="hardware/qcom/display-legacy" name="androidarmv6/android_hardware_qcom_display-legacy" revision="cm-10.2" />
-  <project path="hardware/qcom/media-legacy" name="androidarmv6/android_hardware_qcom_media_legacy" revision="cm-10.2" />
+  <project path="hardware/qcom/display-legacy" name="androidarmv6/android_hardware_qcom_display-legacy" revision="cm-11.0" />
+  <project path="hardware/qcom/media-legacy" name="androidarmv6/android_hardware_qcom_media_legacy" revision="cm-11.0" />
 
 </manifest>


### PR DESCRIPTION
It's better to use cm-11.0 branches for pac-4.4 rather than cm-10.2
